### PR TITLE
Handles non monotonic clocks correctly.

### DIFF
--- a/benchmark/macro.rkt
+++ b/benchmark/macro.rkt
@@ -69,7 +69,9 @@
   (foldr cp-2 (list (list)) ls))
 
 (define (racket-time-extract-result str)
-  (let* ([m (regexp-match #rx"cpu time: ([0-9]+) real time: ([0-9]+) gc time: ([0-9]+)" str)])
+  (let* ([m (regexp-match
+             #rx"cpu time: (-?[0-9]+) real time: (-?[0-9]+) gc time: (-?[0-9]+)"
+             str)])
     (if (not m)
         (error (format "Could not parse time output: ~a" str))
         (string->number (caddr m)))))


### PR DESCRIPTION
The racket `time` call is not monotonic.
The function `racket-time-extract-result` now properly handles
benchmark results of negative times.
